### PR TITLE
MOSIP-28155-data-share-getting-error-when-type-of-share-is-data-share

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ API documentation is available [here](https://docs.mosip.io/1.2.0/api).
 
 ## License
 This project is licensed under the terms of [Mozilla Public License 2.0](LICENSE).
+


### PR DESCRIPTION
creating a dummy commit to rebuild the release-1201 with latest khazana library.