### PR TITLE
[MOSIP-35455] Changing the pom version to 1.3.0-SNAPSHOT for next release.

### DIFF
--- a/data-share/data-share-service/pom.xml
+++ b/data-share/data-share-service/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>io.mosip.datashare</groupId>
         <artifactId>data-share</artifactId>
-        <version>1.3.0-beta.1</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>data-share-service</artifactId>
-    <version>1.3.0-beta.1</version>
+    <version>1.3.0-SNAPSHOT</version>
     <name>data-share-service</name>
 
     <properties>

--- a/data-share/pom.xml
+++ b/data-share/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>io.mosip.datashare</groupId>
         <artifactId>durian</artifactId>
-        <version>1.3.0-beta.1</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>data-share</artifactId>
-    <version>1.3.0-beta.1</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>data-share</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.mosip.datashare</groupId>
     <artifactId>durian</artifactId>
-    <version>1.3.0-beta.1</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>MOSIP Durian Parent POM</name>


### PR DESCRIPTION
[MOSIP-35455] Changing the pom version to 1.3.0-SNAPSHOT for next release.

[MOSIP-35455]: https://mosip.atlassian.net/browse/MOSIP-35455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ