### PR TITLE
[MOSIP-41322] Datashare pod slow because no of request allowed is less count

### DIFF
--- a/data-share/data-share-service/src/main/java/io/mosip/datashare/service/impl/DataShareServiceImpl.java
+++ b/data-share/data-share-service/src/main/java/io/mosip/datashare/service/impl/DataShareServiceImpl.java
@@ -299,7 +299,7 @@ public class DataShareServiceImpl implements DataShareService {
 			throw new DataShareNotFoundException();
 		}else {
 			dataShareGetResponse.setSignature((String) metaDataMap.get(SIGNATURE));
-			int transactionAllowed = metaDataMap.get(TRANSACTIONSALLOWED) != null ? Integer.parseInt((String) metaDataMap.get(TRANSACTIONSALLOWED)) : 0;
+			int transactionAllowed = Integer.parseInt((String) metaDataMap.get(TRANSACTIONSALLOWED));
 			if(transactionAllowed >= 1) {
 				isDataShareAllow=true;
 				metaDataMap.put(TRANSACTIONSALLOWED, transactionAllowed- 1);

--- a/data-share/data-share-service/src/main/java/io/mosip/datashare/service/impl/DataShareServiceImpl.java
+++ b/data-share/data-share-service/src/main/java/io/mosip/datashare/service/impl/DataShareServiceImpl.java
@@ -299,11 +299,11 @@ public class DataShareServiceImpl implements DataShareService {
 			throw new DataShareNotFoundException();
 		}else {
 			dataShareGetResponse.setSignature((String) metaDataMap.get(SIGNATURE));
-			int transactionAllowed = Integer.parseInt((String) metaDataMap.get(TRANSACTIONSALLOWED));
+			int transactionAllowed = metaDataMap.get(TRANSACTIONSALLOWED) != null ? Integer.parseInt((String) metaDataMap.get(TRANSACTIONSALLOWED)) : 0;
 			if(transactionAllowed >= 1) {
 				isDataShareAllow=true;
-				objectStoreAdapter.decMetadata(subcriberId, policyId, null, null, randomShareKey,
-						"transactionsallowed");
+				metaDataMap.put(TRANSACTIONSALLOWED, transactionAllowed- 1);
+				objectStoreAdapter.addObjectMetaData(subcriberId, policyId, null, null, randomShareKey, metaDataMap);
 				LOGGER.info(LoggerFileConstant.SESSIONID.toString(), LoggerFileConstant.POLICYID.toString(), policyId,
 						"Successfully update the metadata");
 			}

--- a/data-share/data-share-service/src/main/java/io/mosip/datashare/util/RestUtil.java
+++ b/data-share/data-share-service/src/main/java/io/mosip/datashare/util/RestUtil.java
@@ -56,13 +56,11 @@ import io.mosip.kernel.core.util.TokenHandlerUtil;
 @Component
 public class RestUtil {
 
-	@Value("${data.share.default.resttemplate.httpclient.connections.max.per.host:20}")
+	@Value("${mosip.data.share.restTemplate.max-connection-per-route:20}")
 	private int maxConnectionPerRoute;
 
-	@Value("${data.share.default.resttemplate.httpclient.connections.max:100}")
+	@Value("${mosip.data.share.restTemplate.total-max-connections:100}")
 	private int totalMaxConnection;
-
-	private RestTemplate restTemplate;
 
 	/** The environment. */
     @Autowired
@@ -70,6 +68,7 @@ public class RestUtil {
 
 	/** The Constant AUTHORIZATION. */
     private static final String AUTHORIZATION = "Authorization=";
+
 	private RestTemplate localRestTemplate;
 
 	@PostConstruct
@@ -225,7 +224,7 @@ public class RestUtil {
 					.loadTrustMaterial(null, acceptingTrustStrategy).build();
 			SSLConnectionSocketFactory csf = new SSLConnectionSocketFactory(sslContext);
 			HttpClientBuilder httpClientBuilder = HttpClients.custom().setMaxConnPerRoute(maxConnectionPerRoute)
-					.setMaxConnTotal(totalMaxConnection).setSSLSocketFactory(csf).disableCookieManagement();
+					.setMaxConnTotal(totalMaxConnection).setSSLSocketFactory(csf);
 			HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
 
 			requestFactory.setHttpClient(httpClientBuilder.build());


### PR DESCRIPTION
Datashare pod slow because no of request allowed is less count