### PR TITLE
MOSIP-44198 Update khazana dependency version

### DIFF
--- a/data-share/data-share-service/pom.xml
+++ b/data-share/data-share-service/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>io.mosip.commons</groupId>
             <artifactId>khazana</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
@@ -303,3 +303,4 @@
     </profiles>
 
 </project>
+


### PR DESCRIPTION
Updated version of 'khazana' dependency to 1.3.1-SNAPSHOT.